### PR TITLE
fix: "missing header file"

### DIFF
--- a/includes/ft_ping.h
+++ b/includes/ft_ping.h
@@ -9,6 +9,7 @@
 # include <sys/socket.h>
 # include <netdb.h>
 # include <arpa/inet.h>
+# include <signal.h>
 
 /**
  * @brief arguments struct


### PR DESCRIPTION
SIGINIT wasn't found while compiling (for Linux Users)